### PR TITLE
Add support to signed release builds and add sending to Telegram

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,6 @@
 name: Build the app
-on: [push]
+on:
+  - push
 
 jobs:
   build:
@@ -8,10 +9,13 @@ jobs:
     
     steps:
     - uses: actions/checkout@v2
+    
     - uses: actions/setup-node@v1
       with:
         node-version: '10.x'
+    
     - run: npm install
+    
     - run: webpack 
     
     - name: Update package list
@@ -23,6 +27,12 @@ jobs:
     - name: Install jq
       run: sudo apt install jq
       
+    - name: Save revision and branch
+      run: |
+        echo "::set-env name=SHORT_REV::$(git rev-parse --short HEAD)"
+        echo "::set-env name=LONG_REV::$(git rev-parse HEAD)"
+        echo "::set-env name=BRANCH::$(sed 's/-/_/g' <<< `git rev-parse --abbrev-ref HEAD`)"
+        
     - name: Install cordova
       run: |
         sudo npm config set unsafe-perm true && \
@@ -31,25 +41,48 @@ jobs:
     - name: Setup build type
       run: echo "::set-env name=BUILD_TYPE::$BUILD_TYPE"
       env:
-        BUILD_TYPE: debug
+        BUILD_TYPE: release
+    
+    - name: Add platform android
+      run: cordova platform add android
+    
+    - name: Save keystore
+      env:
+        keystore_encoded: ${{ secrets.KEYSTORE_ENCODED }}
+      run: |-
+        base64 -d <<< "$keystore_encoded" > platforms/android/acode.keystore
+    
+    - name: Save properties
+      env:
+        signing_properties: ${{ secrets.SIGNING_PROPERTIES }}
+      run: echo "$signing_properties" > platforms/android/release-signing.properties
     
     - name: Build with cordova
-      run: |
-        cordova platform add android && \
-        cordova build android --${BUILD_TYPE}
+      run: cordova build android --${BUILD_TYPE} && rm platforms/android/{*.keystore,release-signing.properties}
     
     - name: Create env variable APP_VERSION
       run: echo "::set-env name=APP_VERSION::$(cat package.json | jq -r '.version')"
     
     - name: Create env variable APP_NAME
-      run: echo "::set-env name=APP_NAME::app-${BUILD_TYPE}.apk"
+      run: echo "::set-env name=APP_NAME::acode-${BUILD_TYPE}-${SHORT_REV}.apk"
       
     
     - name: Rename apk to APP_NAME
-      run: mv platforms/android/app/build/outputs/apk/debug/app-${BUILD_TYPE}.apk ${APP_NAME}
+      run: mv platforms/android/app/build/outputs/apk/${BUILD_TYPE}/app-${BUILD_TYPE}.apk ${APP_NAME}
         
     - name: Upload apk
       uses: actions/upload-artifact@v1
       with:
         name: ${{ env.APP_NAME }}
         path: ${{ env.APP_NAME }}
+        
+    
+    - name: Send apk to Telegram
+      env:
+        chat_id: ${{ secrets.CHAT_ID }}
+        bot_token: ${{ secrets.BOT_TOKEN }}
+      run: |-
+        curl -F "chat_id=${chat_id}" -F 'parse_mode=Markdown' -F caption="$(TZ=UTC git log -1 --format='Commit [%h](https://github.com/deadlyjack/code-editor/commit/%H) #'${BRANCH}'
+        Date: %cd
+        
+        %B' --date='format-local:%a %b %d %Y %T (%z)' | sed 's/[*_`]/\\\0/g')" -F document="@${APP_NAME}" -X POST https://api.telegram.org/bot${bot_token}/sendDocument


### PR DESCRIPTION
It requires 4 github actions secrets:

1. `CHAT_ID`
    The Telegram chat id of the chat where the bot will send the builds to
2. `BOT_TOKEN`
    The Telegram bot token got from [@BotFather](https://t.me/botfather)
3. `KEYSTORE_ENCODED`
    The base64-encoded .keystore content (you can use `base64 <FILE>` on CLI, replacing <FILE> with the proper file name)
4. `SIGNING_PROPERTIES`
    The content to write to platforms/android/release-signing.properties. Example:
```
storeFile=acode.keystore
storeType=jks
keyAlias=alias
keyPassword=mypassword
storePassword=mypassword
```
Just don't touch storeFile, because the workflow will decode the KEYSTORE_ENCODED value and save to acode.keystore. If you didn't specify a keyPassword while generating the key, use the same value of storePassword (you may know, but it got me into some headache)