### PR TITLE
Do not vibrate when vibration setting is turned off

### DIFF
--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -717,7 +717,7 @@ function EditorManager($sidebar, $header, $body) {
             let classFlag = false;
 
             $placeholder.style.opacity = '0';
-            navigator.vibrate(constants.VIBRATION_TIME);
+            if (appSettings.value.vibrateOnTap) navigator.vibrate(constants.VIBRATION_TIME);
             document.ontouchmove = document.onmousemove = null;
             document.addEventListener(type, drag, opts);
 

--- a/src/lib/handlers/selectword.js
+++ b/src/lib/handlers/selectword.js
@@ -73,7 +73,7 @@ function select(type) {
 
   setTimeout(() => {
     container.append($start, $end, $cm);
-    navigator.vibrate(constants.VIBRATION_TIME);
+    if (appSettings.value.vibrateOnTap) navigator.vibrate(constants.VIBRATION_TIME);
     updateControls();
   }, 100);
 

--- a/src/lib/openFolder.js
+++ b/src/lib/openFolder.js
@@ -198,7 +198,7 @@ function openFolder(_path, opts = {}) {
    */
   function handleContextmenu(type, url, name, $target) {
 
-    navigator.vibrate(constants.VIBRATION_TIME);
+    if (appSettings.value.vibrateOnTap) navigator.vibrate(constants.VIBRATION_TIME);
     const cancel = strings.cancel + (clipBoard ? ' (' + strings[clipBoard.action] + ')' : '');
     const COPY = ['copy', strings.copy, 'copy'],
       CUT = ['cut', strings.cut, 'cut'],

--- a/src/pages/fileBrowser/fileBrowser.include.js
+++ b/src/pages/fileBrowser/fileBrowser.include.js
@@ -429,7 +429,7 @@ function FileBrowserInclude(type, option) {
 
       function cmhandle() {
         const enabled = (currentDir.url === "/" && !!uuid) || currentDir.url !== "/";
-        navigator.vibrate(constants.VIBRATION_TIME);
+        if (appSettings.value.vibrateOnTap) navigator.vibrate(constants.VIBRATION_TIME);
         dialogs.select('', [
             ['delete', strings.delete, 'delete', enabled],
             ['rename', strings.rename, 'edit', enabled]


### PR DESCRIPTION
Why disabling the "Vibrate on tap" setting does not remove vibrations in some cases (like long tapping on a word to select it)? Vibrations sometimes can be very annoying. So much annoying that they can force a person to fix this bug-like behavior and make a pull-request :)

(sorry for the newlines at the end of files, they were automatically added by github's built-in editor)