### PR TITLE
Don't rely on res.statusText when checking github response status

### DIFF
--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -162,7 +162,7 @@ function Record(owner, sha, name, data, repo, path, branch) {
         dialogs.loader.create(name, strings.loading + '...');
         repository.deleteFile(branch, _path)
           .then(res => {
-            if (res.statusText === 'OK') {
+            if (res.status === 200) {
               _path = getPath(str);
               return repository.writeFile(branch, _path, data, `Rename ${name} to ${str}`, {});
             }
@@ -170,7 +170,7 @@ function Record(owner, sha, name, data, repo, path, branch) {
             return Promise.reject(res);
           })
           .then(res => {
-            if (res.statusText === 'Created') {
+            if (res.status ===201) {
               _record.name = str;
               _record.commitMessage = `update ${str}`;
               update();
@@ -211,7 +211,7 @@ function Record(owner, sha, name, data, repo, path, branch) {
         dialogs.loader.create(name, strings.saving + '...');
         repository.writeFile(branch, _path, txt, commitMessage, {})
           .then(res => {
-            if (res.statusText === 'OK') {
+            if (res.status === 200) {
               update(txt);
               resolve();
             } else {
@@ -403,7 +403,7 @@ function Gist(id, files, isNew, _public) {
       gist.update(update)
         .then(res => {
           if (!res) return Promise.reject('No response');
-          if (res.status === 200 || res.statusText === 'OK') {
+          if (res.status === 200) {
 
             if (isDelete) {
               delete _this.files[name];
@@ -443,7 +443,7 @@ function Gist(id, files, isNew, _public) {
       dialogs.loader.create(name, strings.loading + '...');
       gist.update(update)
         .then(res => {
-          if (res.status === 200 || res.statusText === 'OK') {
+          if (res.status === 200) {
 
             resolve();
           } else {

--- a/src/pages/info/info.js
+++ b/src/pages/info/info.js
@@ -13,7 +13,7 @@ export default function Info(repo, owner) {
   dialogs.loader.create(repo, strings.loading + '...');
   repository.getReadme('master', false)
     .then(res => {
-      if (res.statusText === 'OK') {
+      if (res.status === 200) {
         const data = res.data;
         let text = data.content;
         if (data.encoding === 'base64') {
@@ -28,7 +28,7 @@ export default function Info(repo, owner) {
       }
     })
     .then(res => {
-      if (res.statusText === 'OK') {
+      if (res.status === 200) {
         const text = res.data;
         $page.append(tag('div', {
           id: 'info-page',


### PR DESCRIPTION
This fix changes code regarding `res.statusText` in if statements.
This fixes #155, and an issue where commiting a file would give an empty error, but would still succeed.
